### PR TITLE
require at least dbal 2.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,9 @@ php:
   - 5.6
   - 7
 
-env:
-  - DOCTRINE_VERSION=2.4.*
-  - DOCTRINE_VERSION=^2.5
-
 before_script:
   - composer self-update
-  - composer require doctrine/dbal:${DOCTRINE_VERSION} --dev --prefer-source
-  - composer install --prefer-source
+  - composer update
 
 script:
   - ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.doctrine-$DOCTRINE_VERSION.xml

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "~5.5|~7.0",
         "prooph/event-store": "dev-develop",
         "prooph/common": "^3.5",
-        "doctrine/dbal": "^2.4"
+        "doctrine/dbal": "^2.5"
     },
     "require-dev": {
         "container-interop/container-interop": "^1.1",


### PR DESCRIPTION
Doctrine DBAL has a bug in 2.4 with PHP7, see: https://bugs.php.net/bug.php?id=70877
