### PR TITLE
[WIP] optimize database scheme

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,16 @@ Doctrine Adapter for the Snapshot Store
 
 ## Set Up
 
-How to use the adapter is explained in the [prooph/event-store docs](https://github.com/prooph/event-store/blob/master/docs/snapshots.md). To help you with setting up the snapshot tables we ship a [SnapshotStoreSchema](src/Schema/SnapshotStoreSchema.php) helper with the package. You can use it in a doctrine migrations script or manually by passing in a `Doctrine\DBAL\Schema\Schema` and executing the generated SQL afterwards.
+How to use the adapter is explained in the 
+[prooph/event-store docs](https://github.com/prooph/event-store/blob/master/docs/snapshots.md). To help you with 
+setting up the snapshot tables we ship a [SnapshotStoreSchema](src/Schema/SnapshotStoreSchema.php) helper with the 
+package. You can use it in a Doctrine migrations script or manually by passing in a `Doctrine\DBAL\Schema\Schema` and 
+executing the generated SQL afterwards.
+
+> The database schema is only a suggestion. The `aggregate_type` column has a length of 150 chars. If you have very 
+long class names you should increase this length, otherwise it could lead to errors in your application. This length
+should be equal with the `aggregate_type` length in the 
+[event store table](https://github.com/prooph/event-store-doctrine-adapter "Doctrine Adapter for ProophEventStore").
 
 ## Interop Factory
 

--- a/src/DoctrineSnapshotAdapter.php
+++ b/src/DoctrineSnapshotAdapter.php
@@ -58,8 +58,8 @@ final class DoctrineSnapshotAdapter implements Adapter
         $queryBuilder
             ->select('*')
             ->from($table, $table)
-            ->where('aggregate_type = :aggregate_type')
-            ->andWhere('aggregate_id = :aggregate_id')
+            ->where('aggregate_id = :aggregate_id')
+            ->andWhere('aggregate_type = :aggregate_type')
             ->orderBy('last_version', 'DESC')
             ->setParameter('aggregate_type', $aggregateType->toString())
             ->setParameter('aggregate_id', $aggregateId)
@@ -114,8 +114,8 @@ final class DoctrineSnapshotAdapter implements Adapter
         $table = $this->getTable($snapshot->aggregateType());
         $queryBuilder
             ->delete($table)
-            ->where('aggregate_type = :aggregate_type')
-            ->andWhere('aggregate_id = :aggregate_id')
+            ->where('aggregate_id = :aggregate_id')
+            ->andWhere('aggregate_type = :aggregate_type')
             ->andWhere('last_version < :last_version')
             ->setParameter('aggregate_type', $snapshot->aggregateType()->toString())
             ->setParameter('aggregate_id', $snapshot->aggregateId())

--- a/src/Schema/SnapshotStoreSchema.php
+++ b/src/Schema/SnapshotStoreSchema.php
@@ -32,13 +32,17 @@ final class SnapshotStoreSchema
     {
         $snapshot = $schema->createTable($snapshotName);
 
-        $snapshot->addColumn('aggregate_type', 'string');
-        $snapshot->addColumn('aggregate_id', 'string');
-        $snapshot->addColumn('last_version', 'integer');
-        $snapshot->addColumn('created_at', 'string');
+        // UUID4 of linked aggregate
+        $snapshot->addColumn('aggregate_id', 'string', ['fixed' => true, 'length' => 36]);
+        // Class of the linked aggregate
+        $snapshot->addColumn('aggregate_type', 'string', ['length' => 150]);
+        // Version of the aggregate after event was recorded
+        $snapshot->addColumn('last_version', 'integer', ['unsigned' => true]);
+        // DateTime ISO8601 + microseconds UTC stored as a string e.g. 2016-02-02T11:45:39.000000
+        $snapshot->addColumn('created_at', 'string', ['fixed' => true, 'length' => 26]);
         $snapshot->addColumn('aggregate_root', 'blob');
 
-        $snapshot->addIndex(['aggregate_type', 'aggregate_id']);
+        $snapshot->addIndex(['aggregate_id', 'aggregate_type']);
     }
 
     /**


### PR DESCRIPTION
This uses the most optimized available type of the column. The multicolumn index has switched to have the shortest/fastest index in the first place.

There is one more optimization. The `aggregate_type` column could be a partial index of length 20 for example. I'm still figuring that out, how to set it with Doctrine Migrations.

Has the DateTime ISO8601 + microseconds UTC format always a length of 26?

_Note:_ I think there is no major release necessary. Because columns are the same and nothing happens if the migration already exists.
